### PR TITLE
Fix 0.5.32/0.5.33 load error

### DIFF
--- a/CoC2SaveEditor.html
+++ b/CoC2SaveEditor.html
@@ -23556,7 +23556,15 @@ h4 {
                 throw new Error('File read result not a string');
             }
             try {
-                saveObj = JSON.parse(state.fileReader.result);
+                let saveData;
+                let saveDataRaw = JSON.parse(state.fileReader.result);
+                if (saveDataRaw.data) {
+                    saveData = JSON.parse(saveDataRaw.data);
+                }
+                else {
+                    saveData = saveDataRaw;
+                }
+                saveObj = saveData;
             }
             catch (err) {
                 alert("Error parsing file");


### PR DESCRIPTION
Fixes #5 

The save file structure seems to have changed between versions. The new files have a `data` property where the save data is actually located. There's also an `icon` property, no idea what it is for, but creating a save from scratch sets it to an empty string by default.

This should probably only be a temporary fix and looked at in more detail.